### PR TITLE
Add visibility column and PAT support

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -31,6 +31,7 @@ Features
     - CONFLICT       (red)      - Merge conflict
     - DESYNCHRONIZED (red)      - Dirty & behind remote
     - Submodules: "Yes" (green) or "(none)" (gray) for each repo.
+    - Visibility column shows PUBLIC, PRIVATE, or RESTRICTED for each repo.
 - Groups repositories by status for prompts and action.
 - Prompts once per group:
     - Update all out-of-date/obsolete repositories? (fetch, then pull if clean)
@@ -49,7 +50,12 @@ Requirements
 
 Usage
 -----
-    ./git-haul.py [--org <github-org>] [<github-org>:]<github-user>@<github-host-ssh-alias> <local-root-path>
+    ./git-haul.py [--org <github-org>] [--github-pat <token>] \
+        [<github-org>:]<github-user>@<github-host-ssh-alias> <local-root-path>
+
+Set the environment variable `GITHAUL_GITHIB_PAT` to supply a Personal Access
+Token without exposing it on the command line. Using `--github-pat` is allowed
+but will trigger a security warning at runtime.
 
 Examples:
     ./git-haul.py jdobbs@github-yoyodyne ~/src/yoyodyne
@@ -66,6 +72,7 @@ Examples:
 
   - If you only use a single GitHub account and SSH key, you can use 'github.com' as the alias.
   - The local-root-path is the directory where all repositories will be checked for and managed. Each repo is expected as a subdirectory directly beneath this path, named after the repo.
+  - To work with private or restricted repositories, set the `GITHAUL_GITHIB_PAT` environment variable with a valid Personal Access Token. See `docs/SECURITY.TXT` for guidance.
 
 Prompts & Actions
 -----------------
@@ -78,7 +85,7 @@ Prompts & Actions
 
 Safety & Limitations
 --------------------
-- Only repositories you can access are shown (public or private as allowed by your credentials).
+- Only repositories you can access are shown (public, private, or restricted if your token allows).
 - No repo is ever reset, merged, or committed to by this script.
 - All local changes, stashes, and untracked files are **left untouched**.
 - Post-action summary shows updated repo status in a new colorized table.
@@ -96,4 +103,6 @@ Author
 License
 -------
 MIT, no warranty.
+
+See `docs/SECURITY.TXT` for information on securing your GitHub credentials.
 

--- a/docs/SECURITY.TXT
+++ b/docs/SECURITY.TXT
@@ -1,0 +1,20 @@
+Git-haul Security Guidance
+==========================
+
+Git-haul retrieves repository information from GitHub. When accessing private or
+restricted repositories, you must authenticate with a Personal Access Token
+(PAT) that has appropriate scopes for repository access.
+
+Supplying a PAT on the command line (`--github-pat=<token>`) exposes it to
+process listings. The recommended approach is to set the environment variable
+`GITHAUL_GITHIB_PAT` before running the tool. Git-haul will automatically use the
+value from the environment if present.
+
+Keep your PAT secure:
+
+- Store it in a protected environment variable or credential store.
+- Use the least privileges necessary.
+- Rotate or revoke the token if it ever becomes exposed.
+
+Org-level materials such as SSH certificates or tokens should be handled in
+accordance with your organization's security policies.

--- a/tests/test_githaul.py
+++ b/tests/test_githaul.py
@@ -1,0 +1,36 @@
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import githaul
+from rich.console import Console
+
+
+def test_parse_org_user_alias_user_only():
+    org, user, alias = githaul.parse_org_user_alias("alice@gh")
+    assert org is None
+    assert user == "alice"
+    assert alias == "gh"
+
+
+def test_parse_org_user_alias_org_prefix():
+    org, user, alias = githaul.parse_org_user_alias("Acme:alice@gh")
+    assert org == "Acme"
+    assert user == "alice"
+    assert alias == "gh"
+
+
+def test_display_table_has_visibility_column():
+    githaul.console = Console(record=True)
+    sample = [{
+        'name': 'repo1',
+        'visibility': 'PUBLIC',
+        'status': 'SYNCHRONIZED',
+        'branch': 'main',
+        'path': '',
+        'remote_url': '',
+        'has_submodules': False
+    }]
+    githaul.display_repos_table(sample, title="Test")
+    out = githaul.console.export_text()
+    assert "VISIBILITY" in out


### PR DESCRIPTION
## Summary
- show repo visibility (public, private, or restricted) in reports
- support Personal Access Token via `--github-pat` or `GITHAUL_GITHIB_PAT`
- document PAT usage and new visibility column
- add security guidelines
- test parsing and table display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a2875e944832f914594a337f30921